### PR TITLE
9 parallel

### DIFF
--- a/conc_queue.hpp
+++ b/conc_queue.hpp
@@ -33,6 +33,22 @@ class concurrent_queue
 		return queue_.empty();
 	}
 
+	bool unlocked_empty() const
+	{
+		return queue_.empty();
+	}
+
+	bool unlocked_pop(Data &popped)
+	{
+		if (queue_.empty())
+			return false;
+
+		popped = queue_.front();
+		queue_.pop();
+
+		return true;
+	}
+
 	// push item onto the queue, wait up to ms if q full
 	bool push_with_timeout(Data const& data, int ms)
 	{

--- a/kinesis_consumer.cpp
+++ b/kinesis_consumer.cpp
@@ -200,6 +200,8 @@ kinesis_client_destroy(kinesis_client *client)
 	delete (KinesisClient *)(client);
 }
 
+// parse a formatted seqnum such as 'after_sequence_number:324342423..' and
+// set the appropriate options on a shard iterator request
 static bool
 parse_seqnum(GetShardIteratorRequest &request, const char *seqnum)
 {
@@ -255,8 +257,6 @@ kinesis_consumer_create(kinesis_client *k,
 
 	if (!ok)
 		AWS_LOG_ERROR("kinesis_consumer", "could not parse seq %s", seqnum);
-
-	AWS_LOG_INFO("kinesis_consumer", "start seq %s", seqnum);
 
 	auto outcome = kc->GetShardIterator(request);
 

--- a/kinesis_consumer.cpp
+++ b/kinesis_consumer.cpp
@@ -295,6 +295,13 @@ kinesis_consumer_destroy(kinesis_consumer *kc)
 	if (kc->keep_running)
 		kinesis_consumer_stop(kc);
 
+	while (!kc->queue->unlocked_empty())
+	{
+		GetRecordsOutcome *popped;
+		kc->queue->unlocked_pop(popped);
+		delete popped;
+	}
+
 	delete kc->queue;
 	delete kc;
 }

--- a/pipeline_kinesis--0.9.0.sql
+++ b/pipeline_kinesis--0.9.0.sql
@@ -11,7 +11,7 @@ CREATE TABLE pipeline_kinesis.endpoints (
 -- Consumers added with pipeline_kinesis.consume_begin
 CREATE TABLE pipeline_kinesis.consumers (
   id serial PRIMARY KEY,
-  endpoint text references pipeline_kinesis.endpoints(name),
+  endpoint text REFERENCES pipeline_kinesis.endpoints(name),
   stream text NOT NULL,
   relation text NOT NULL,
   format text    NOT NULL,
@@ -24,7 +24,7 @@ CREATE TABLE pipeline_kinesis.consumers (
 );
 
 CREATE TABLE pipeline_kinesis.seqnums (
-  consumer_id int references pipeline_kinesis.consumers(id),
+  consumer_id int REFERENCES pipeline_kinesis.consumers(id),
   shard_id text NOT NULL,
   seqnum text NOT NULL,
   PRIMARY KEY(consumer_id, shard_id)

--- a/pipeline_kinesis.c
+++ b/pipeline_kinesis.c
@@ -621,7 +621,6 @@ kinesis_consume_main(Datum arg)
 	BackgroundWorkerUnblockSignals();
 
 	id = Int32GetDatum(arg);
-
 	cinfo = hash_search(consumer_info, &id, HASH_FIND, &found);
 
 	Assert(found);

--- a/pipeline_kinesis.c
+++ b/pipeline_kinesis.c
@@ -920,9 +920,6 @@ kinesis_consume_begin_sr(PG_FUNCTION_ARGS)
 
 	para = DatumGetInt32(values[8]);
 
-//	if (para > MAX_PROCS)
-//		elog(ERROR, "max parallelism per stream is %d", MAX_PROCS);
-
 	SPI_connect();
 
 	rv = SPI_execute_with_args(query, 9, argtypes, values, nulls, false, 1);
@@ -1017,9 +1014,7 @@ kinesis_consume_end_sr(PG_FUNCTION_ARGS)
 	Assert(info);
 
 	for (i = 0; i < info->num_procs; ++i)
-	{
 		TerminateBackgroundWorker(&info->handle[i]);
-	}
 
 	hash_search(consumer_info, &id, HASH_REMOVE, &found);
 


### PR DESCRIPTION
Fixes #9, #10 and #11 

Adds support for parallel bgworkers
Uses serial for consumer id in kinesis schema
Adds support for start_seq (uses -1, and -2 to refer to LATEST and TRIM_HORIZON respectively)

Some smaller fixes to do with error handling and resource cleanup also.
