### PR TITLE
Add throughput exceeded throttle, beef up error handling and logging

### DIFF
--- a/kinesis_consumer.h
+++ b/kinesis_consumer.h
@@ -43,7 +43,7 @@ void kinesis_client_destroy_stream_metadata(kinesis_stream_metadata *meta);
 
 void kinesis_client_destroy(kinesis_client *client);
 
-void kinesis_set_logger(void *ctx, kinesis_log_fn fn);
+void kinesis_set_logger(void *ctx, kinesis_log_fn fn, const char *level);
 
 kinesis_consumer * kinesis_consumer_create(kinesis_client *client,
 										   const char *stream,

--- a/pipeline_kinesis.c
+++ b/pipeline_kinesis.c
@@ -646,7 +646,7 @@ kinesis_consume_main(Datum arg)
 	load_consumer_state(&state, id);
 	copy = get_copy_statement(&state);
 
-	kinesis_set_logger(NULL, log_fn);
+	kinesis_set_logger(NULL, log_fn, "warn");
 
 	client = kinesis_client_create(state.endpoint_region,
 			state.endpoint_credfile,


### PR DESCRIPTION
Throttle requests when a throughput exception is detected.
Set default logging level to warn
Add a parameter to set logging level
