### PR TITLE
6 creds

### DIFF
--- a/kinesis_consumer.cpp
+++ b/kinesis_consumer.cpp
@@ -35,7 +35,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/time.h>
-#include <fstream>
 
 using namespace Aws::Auth;
 using namespace Aws::Client;

--- a/kinesis_consumer.cpp
+++ b/kinesis_consumer.cpp
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <fstream>
 
 using namespace Aws::Auth;
 using namespace Aws::Client;
@@ -164,9 +165,11 @@ kinesis_client_create(const char *region,
 	config.retryStrategy = 
 		Aws::MakeShared<DefaultRetryStrategy>("kinesis_consumer", 5, 25);
 
-	// TODO - handle creds and url
-	(void) (credfile);
-	(void) (url);
+	if (credfile)
+		setenv("AWS_SHARED_CREDENTIALS_FILE", credfile, 1);
+
+	if (url)
+		config.endpointOverride = url;
 
 	KinesisClient *kc = new KinesisClient(config);
 	return (kinesis_client *)(kc);

--- a/kinesis_consumer.cpp
+++ b/kinesis_consumer.cpp
@@ -23,6 +23,7 @@
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws/kinesis/model/DescribeStreamRequest.h>
 #include <aws/core/utils/StringUtils.h>
+#include <aws/core/http/Scheme.h>
 
 #include "kinesis_consumer.h"
 #include "conc_queue.hpp"
@@ -148,6 +149,28 @@ lookup_region(const char *r)
 	return -1;
 }
 
+static void
+parse_url(ClientConfiguration &config,
+		  const char *url)
+{
+	const char *iter = url;
+	const char *tok = iter;
+
+	while (*iter && *iter != ':') ++iter;
+
+	Aws::String scheme(tok, iter);
+
+	while (*iter && (*iter == ':' || *iter == '/')) ++iter;
+	tok = iter;
+
+	while (*iter) ++iter;
+
+	Aws::String rest(tok, iter);
+
+	config.scheme = Aws::Http::SchemeMapper::FromString(scheme.c_str());
+	config.endpointOverride = rest;
+}
+
 kinesis_client * 
 kinesis_client_create(const char *region,
 					  const char *credfile,
@@ -168,7 +191,7 @@ kinesis_client_create(const char *region,
 		setenv("AWS_SHARED_CREDENTIALS_FILE", credfile, 1);
 
 	if (url)
-		config.endpointOverride = url;
+		parse_url(config, url);
 
 	KinesisClient *kc = new KinesisClient(config);
 	return (kinesis_client *)(kc);

--- a/pipeline_kinesis--0.9.0.sql
+++ b/pipeline_kinesis--0.9.0.sql
@@ -33,7 +33,7 @@ CREATE TABLE pipeline_kinesis.seqnums (
 CREATE FUNCTION pipeline_kinesis.add_endpoint (
   name text,
   region text,
-  credfile text,
+  credfile text DEFAULT NULL,
   url text DEFAULT NULL
 )
 RETURNS text

--- a/pipeline_kinesis.c
+++ b/pipeline_kinesis.c
@@ -132,7 +132,11 @@ kinesis_add_endpoint(PG_FUNCTION_ARGS)
 
 	values[0] = PG_GETARG_DATUM(0);
 	values[1] = PG_GETARG_DATUM(1);
-	values[2] = PG_GETARG_DATUM(2);
+
+	if (PG_ARGISNULL(2))
+		nulls[2] = 'n';
+	else
+		values[2] = PG_GETARG_DATUM(2);
 
 	if (PG_ARGISNULL(3))
 		nulls[3] = 'n';
@@ -376,15 +380,17 @@ load_consumer_state(KinesisConsumerState *state, int id)
 	state->endpoint_region =
 		TextDatumGetCString(slot_getattr(slot, 2, &isnull));
 
-	d = slot_getattr(slot, 5, &isnull);
+	d = slot_getattr(slot, 3, &isnull);
 
 	if (!isnull)
 		state->endpoint_credfile = TextDatumGetCString(d);
 
-	d = slot_getattr(slot, 5, &isnull);
+	d = slot_getattr(slot, 4, &isnull);
 
 	if (!isnull)
 		state->endpoint_url = TextDatumGetCString(d);
+
+	/* skip 5 == endpoint name */
 
 	state->kinesis_stream = TextDatumGetCString(slot_getattr(slot, 6, &isnull));
 	state->relation = TextDatumGetCString(slot_getattr(slot, 7, &isnull));


### PR DESCRIPTION
Handle credentials and url override options.

Setting the credfile option will override the path that the kinesis library uses to grab the creds.
If it is NULL, the default behaviour occurs, which is to look in environment variables and the home directory.

endpoint override is useful for testing with things like kinesalite.
